### PR TITLE
Infinite custom roles, set admin/mod/bot as custom roles as an example

### DIFF
--- a/res/settings-skeleton.yaml
+++ b/res/settings-skeleton.yaml
@@ -76,9 +76,6 @@ server_display_color: cyan
 prompt_color: white
 prompt_hash_color: red
 prompt_border_color: magenta
-admin_color: magenta
-mod_color: blue
-bot_color: yellow
 normal_user_color: green
 
 # the "default" text color for messages and other things
@@ -101,13 +98,14 @@ blink_mentions: true
 
 # here you can define your own custom roles - NOTE: text must match exactly!
 # These for example could be "helper" or "trusted", whatever roles
-# your servers use that aren't the default 'admin/mod/bot'
-custom_role:
-custom_role_color:
-custom_role_2:
-custom_role_2_color:
-custom_role_3:
-custom_role_3_color:
+# your servers use
+custom_roles:
+- name: admin
+  color: magenta
+- name: mod
+  color: blue
+- name: bot
+  color: yellow
   
 # Channel ignore list - This stops the channel from being loaded.
 # Effectively like the "mute" + "hide" feature on the official client,

--- a/ui/ui_utils.py
+++ b/ui/ui_utils.py
@@ -36,18 +36,12 @@ async def get_role_color(msg):
     color = ""
     try: 
         r = msg.author.top_role.name.lower()
-        if r == "admin":
-            color = await get_color(settings["admin_color"])
-        elif r == "mod": 
-            color = await get_color(settings["mod_color"])
-        elif r == "bot": 
-            color = await get_color(settings["bot_color"])
-        elif settings["custom_role"] is not None and r == settings["custom_role"].lower():
-            color = await get_color(settings["custom_role_color"])
-        elif settings["custom_role_2"] is not None and r == settings["custom_role_2"].lower():
-            color = await get_color(settings["custom_role_2_color"])
-        elif settings["custom_role_3"] is not None and r == settings["custom_role_3"].lower():
-            color = await get_color(settings["custom_role_3_color"])
+        for role in settings["custom_roles"]:
+            if r == role["name"].lower():
+                color = await get_color(role["color"])
+
+        if color is not "": # The user must have already been assigned a custom role
+            pass
         elif settings["normal_user_color"] is not None:
             color = await get_color(settings["normal_user_color"])
         else: color = term.green


### PR DESCRIPTION
Instead of manually checking if admin, moderator, bot, and three custom roles have been set, it's easier and better to simply iterate over a list of them, allowing for many more custom roles and the ability to condense the program further by adding admin, moderator and bot as custom roles, which also makes for a good example.